### PR TITLE
removed /profile route, with /scheduler route

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 const loginRouter = require('./controllers/routes/login')
-const profileRouter = require('./controllers/routes/profile');
+const schedulerRouter = require('./controllers/routes/scheduler');
 const apiRouter = require('./controllers/api');
 
 // Route for home page
@@ -18,7 +18,7 @@ app.get('/', (req, res) => res.sendFile(path.join(__dirname, '/views/login.html'
 app.use('/login', loginRouter);
 
 // Route for profile page
-app.use('/profile', profileRouter);
+app.use('/scheduler', schedulerRouter);
 
 //Route for API calls
 app.use('/api', apiRouter);

--- a/controllers/routes/index.js
+++ b/controllers/routes/index.js
@@ -1,14 +1,14 @@
-const express = require('express');
+// const express = require('express');
 
-// Import our modular routers for /login, /profile, and /scheduler
-const loginRouter = require('./login');
-const profileRouter = require('./profile');
-const schedulerRouter = require('./scheduler.js');
+// // Import our modular routers for /login, /profile, and /scheduler
+// const loginRouter = require('./login');
+// const profileRouter = require('./profile');
+// const schedulerRouter = require('./scheduler.js');
 
-const app = express();
+// const app = express();
 
-app.use('/scheduler', schedulerRouter);
-// app.use('/login', loginRouter);
-// app.use('/profile', profileRouter);
+// app.use('/scheduler', schedulerRouter);
+// // app.use('/login', loginRouter);
+// // app.use('/profile', profileRouter);
 
-module.exports = app;
+// module.exports = app;

--- a/controllers/routes/profile.js
+++ b/controllers/routes/profile.js
@@ -1,12 +1,12 @@
-const profile = require('express').Router();
-const path = require('path')
-const schedulerRouter = require('./scheduler');
+// const profile = require('express').Router();
+// const path = require('path')
+// const schedulerRouter = require('./scheduler');
 
-profile.get('/', (req, res) => {
-    res.sendFile(path.join(__dirname, '../../views/profile.html'));
-});
+// profile.get('/', (req, res) => {
+//     res.sendFile(path.join(__dirname, '../../views/profile.html'));
+// });
 
-// Define additional routes for /scheduler within the /profile route
-profile.use('/scheduler', schedulerRouter);
+// // Define additional routes for /scheduler within the /profile route
+// profile.use('/scheduler', schedulerRouter);
 
-module.exports = profile;
+// module.exports = profile;


### PR DESCRIPTION
Now we can access the scheduler route "profile page" via **http://localhost.com/scheduler** instead of **http://localhost.com/profile/scheduler**. 